### PR TITLE
fix/0/assemblyprocessmonitoring, gateway: port 번호 충돌 해결 

### DIFF
--- a/assemblyprocessmonitoring/src/main/resources/application.yml
+++ b/assemblyprocessmonitoring/src/main/resources/application.yml
@@ -30,14 +30,14 @@ spring:
       bindings:
         event-in:
           group: assemblyprocessmonitoring
-#<<< EDA / Topic Name
+          #<<< EDA / Topic Name
           destination: carsmartfactory
-#>>> EDA / Topic Name
+          #>>> EDA / Topic Name
           contentType: application/json
         event-out:
-#<<< EDA / Topic Name
+          #<<< EDA / Topic Name
           destination: carsmartfactory
-#>>> EDA / Topic Name
+          #>>> EDA / Topic Name
           contentType: application/json
 
 logging:
@@ -45,9 +45,8 @@ logging:
     org.hibernate.type: trace
     org.springframework.cloud: debug
 
-
 server:
-  port: 8087
+  port: 8090  # 8087 → 8090 변경 (Gateway와 포트 충돌 해결)
 
 ---
 
@@ -80,5 +79,3 @@ spring:
         event-out:
           destination: carsmartfactory
           contentType: application/json
-
-

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -50,7 +50,7 @@ spring:
           predicates:
             - Path=/paintingSurfaceDefectDetectionLogs/**, /paintingProcessEquipmentDefectDetectionLogs/**
         - id: assemblyprocessmonitoring
-          uri: http://localhost:8088
+          uri: http://localhost:8090  # 8088 → 8090 변경 (포트 충돌 해결)
           predicates:
             - Path=/vehicleAssemblyProcessDefectDetectionLogs/**
         - id: weldingprocessmonitoring
@@ -61,14 +61,6 @@ spring:
           uri: http://localhost:8080
           predicates:
             - Path=/**
-      # CORS 설정 완전 제거 - Java SecurityConfig에서 처리
-      # globalcors:
-      #   corsConfigurations:
-      #     '[/**]':
-      #       allowedOrigins: [ "http://localhost:3000" ]
-      #       allowedMethods: [ "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS" ]
-      #       allowedHeaders: [ "*" ]
-      #       allowCredentials: false
 
 ---
 
@@ -119,14 +111,6 @@ spring:
           uri: http://frontend:8080
           predicates:
             - Path=/**
-      # CORS 설정 제거 - Java SecurityConfig에서 처리
-      # globalcors:
-      #   corsConfigurations:
-      #     '[/**]':
-      #       allowedOrigins: [ "http://localhost:3000" ]
-      #       allowedMethods: [ "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS" ]
-      #       allowedHeaders: [ "*" ]
-      #       allowCredentials: false
 
 ---
 
@@ -288,11 +272,3 @@ spring:
           uri: http://frontend:8080
           predicates:
             - Path=/**
-      # CORS 설정 제거 - Java SecurityConfig에서 처리
-      # globalcors:
-      #   corsConfigurations:
-      #     '[/**]':
-      #       allowedOrigins: [ "*" ]
-      #       allowedMethods: [ "*" ]
-      #       allowedHeaders: [ "*" ]
-      #       allowCredentials: false


### PR DESCRIPTION
## ✨ Description 
- Gateway: port 8088 유지 (K8s와 일치)
- assemblyprocessmonitoring: port 8088 → 8090 (Gateway 충돌 해결)
-  paintingprocessmonitoring: 누락된 라우팅 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Changed service port to 8090; gateway routing updated to target the new port across profiles.
  - Removed CORS configuration blocks from configuration profiles (default, docker, kubernetes).

- Style
  - Reformatted YAML: adjusted indentation of topic markers and content-type lines; minor end-of-file formatting cleanup.
  - These formatting updates do not affect runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->